### PR TITLE
StorageClass name change

### DIFF
--- a/charts/nats/templates/certs.yaml
+++ b/charts/nats/templates/certs.yaml
@@ -2,7 +2,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: nats-secrets
+  name: "{{ .Release.Name }}-nats-secrets"
   annotations:
     image/tag: "{{.Values.version}}"
   labels:

--- a/charts/nats/templates/store.yaml
+++ b/charts/nats/templates/store.yaml
@@ -2,7 +2,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: nats-ebs-sc-gp3
+  name: "{{ .Release.Name }}-nats-ebs-sc-gp3"
   labels:
     {{- include "nats.labels" . | nindent 4 }}
 provisioner: ebs.csi.aws.com


### PR DESCRIPTION
StorageClass is a cluster wide resource, and it met conflict when trying to deploy another release with this chart