### PR TITLE
fix: pdb typo

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -1,4 +1,4 @@
 name: app
 description: Deployment for base pinup app
-version: 3.3.5
+version: 3.3.6
 apiVersion: v2

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -254,7 +254,6 @@ hpa:
 
 pdb:
   enabled: false
-  maxUnavailable: 1
 
 configfiles: {}
   # mountPath: "/etc/app"


### PR DESCRIPTION
unable to define MinAvailiable when MaxUnavailiabe is defined by default, the similar issue: https://github.com/cert-manager/cert-manager/pull/6087